### PR TITLE
🐛 Isolate turbo_tests2 worker coverage output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,14 @@ Please file a bug if you notice a violation of semantic versioning.
 
 ### Fixed
 
+- turbo_tests2 workers now write SimpleCov reports under isolated
+  `coverage/turbo_tests/<worker>` directories so only the parent collation step
+  publishes root coverage reports such as `coverage/coverage.json`.
+- turbo_tests2 workers now explicitly disable SimpleCov merge finalization so
+  parent-owned collation remains the only final coverage report writer.
+- turbo_tests2 rake hooks now restore coverage constants before setup or
+  cleanup, preventing post-suite collation failures after specs reload constants.
+
 ### Security
 
 ## [3.0.0] - 2026-07-13

--- a/lib/kettle/soup/cover.rb
+++ b/lib/kettle/soup/cover.rb
@@ -43,6 +43,9 @@ module Kettle
       module_function
 
       VAR_HOME_PREFIX = %r{\A/var/home(?=/|\z)}
+      CHANGE_PATH = File.expand_path("../change.rb", __dir__)
+      CONSTANTS_PATH = File.expand_path("cover/constants.rb", __dir__)
+      LOADERS_PATH = File.expand_path("cover/loaders.rb", __dir__)
 
       def display_path(path)
         return path if path.nil?
@@ -51,7 +54,17 @@ module Kettle
       end
 
       def reset_const(&block)
-        Constants.reset_const(&block)
+        if const_defined?(:Constants, false)
+          Constants.reset_const(&block)
+        else
+          block&.call
+          load(CHANGE_PATH) unless Kettle.const_defined?(:Change, false)
+          load(CONSTANTS_PATH)
+          include Constants
+
+          load(LOADERS_PATH) unless const_defined?(:Loaders, false)
+          extend Loaders
+        end
       end
 
       def delete_const(&block)

--- a/lib/kettle/soup/cover/config.rb
+++ b/lib/kettle/soup/cover/config.rb
@@ -33,6 +33,7 @@ SimpleCov.configure do
 
   # Setup Coverage Dir
   coverage_dir(Kettle::Soup::Cover::Constants::COVERAGE_DIR)
+  finalize_merge(false) if Kettle::Soup::Cover::Constants::TURBO_TESTS_WORKER
 
   # Formatters
   Kettle::Soup::Cover.configure_formatters!

--- a/lib/kettle/soup/cover/constants.rb
+++ b/lib/kettle/soup/cover/constants.rb
@@ -93,7 +93,11 @@ module Kettle
         end
         MIN_COVERAGE_HARD_REQUESTED = ENV_GET.call("MIN_HARD", CI).casecmp?(Constants::TRUE)
         MIN_COVERAGE_HARD = MIN_COVERAGE_HARD_REQUESTED && !TURBO_TESTS_WORKER
-        COVERAGE_DIR = COVERAGE_ROOT_DIR
+        COVERAGE_DIR = if TURBO_TESTS_WORKER
+          File.join(COVERAGE_ROOT_DIR, TURBO_TESTS_DIR, TEST_ENV_NUMBER)
+        else
+          COVERAGE_ROOT_DIR
+        end
         # A wild approximation, but will suffice for nearly all users
         is_mac = RbConfig::CONFIG["host_os"].include?("darwin")
         # Set to "" to prevent opening a browser with the coverage rake task

--- a/lib/kettle/soup/cover/rakelib/turbo_tests.rake
+++ b/lib/kettle/soup/cover/rakelib/turbo_tests.rake
@@ -3,6 +3,7 @@
 namespace :turbo_tests do
   desc "Prepare shared SimpleCov coverage output for turbo_tests2 workers"
   task :setup do
+    Kettle::Soup::Cover.reset_const unless Kettle::Soup::Cover.const_defined?(:Constants, false)
     if Kettle::Soup::Cover.turbo_tests_coverage?
       Kettle::Soup::Cover.clear_coverage_dir!
     end
@@ -10,6 +11,7 @@ namespace :turbo_tests do
 
   desc "Collate turbo_tests2 worker coverage reports"
   task :cleanup do
+    Kettle::Soup::Cover.reset_const unless Kettle::Soup::Cover.const_defined?(:Constants, false)
     Kettle::Soup::Cover.collate_turbo_tests_coverage!
   end
 end

--- a/spec/kettle/soup/cover/constants_spec.rb
+++ b/spec/kettle/soup/cover/constants_spec.rb
@@ -278,9 +278,9 @@ RSpec.describe Kettle::Soup::Cover::Constants do
     let(:turbo_tests) { "true" }
     let(:test_env_number) { "2" }
 
-    it "uses the shared SimpleCov coverage directory with a unique worker command name" do
+    it "uses an isolated worker coverage directory with a unique worker command name" do
       expect(described_class::COVERAGE_ROOT_DIR).to eq("coverage")
-      expect(described_class::COVERAGE_DIR).to eq("coverage")
+      expect(described_class::COVERAGE_DIR).to eq("coverage/parallel/2")
       expect(described_class::SIMPLECOV_COMMAND_NAME).to eq("#{described_class::COMMAND_NAME} (turbo_tests2 worker 2)")
       expect(described_class::TURBO_TESTS_WORKER).to be(true)
       expect(described_class::CLEAN_RESULTSET).to be(false)

--- a/spec/kettle/soup/cover/rakelib/turbo_tests_spec.rb
+++ b/spec/kettle/soup/cover/rakelib/turbo_tests_spec.rb
@@ -21,6 +21,20 @@ RSpec.describe "rake turbo_tests:cleanup" do
 
     expect(Kettle::Soup::Cover).to have_received(:collate_turbo_tests_coverage!)
   end
+
+  it "restores constants before cleanup when a prior spec removed them" do
+    allow(Kettle::Soup::Cover).to receive(:collate_turbo_tests_coverage!).and_return(:collated)
+    Kettle.send(:remove_const, :Change) # rubocop:disable RSpec/RemoveConst
+    Kettle::Soup::Cover.send(:remove_const, :Constants) # rubocop:disable RSpec/RemoveConst
+    Kettle::Soup::Cover.send(:remove_const, :Loaders) # rubocop:disable RSpec/RemoveConst
+
+    rake["turbo_tests:cleanup"].invoke
+
+    expect(Kettle.const_defined?(:Change, false)).to be(true)
+    expect(Kettle::Soup::Cover.const_defined?(:Constants, false)).to be(true)
+    expect(Kettle::Soup::Cover.const_defined?(:Loaders, false)).to be(true)
+    expect(Kettle::Soup::Cover).to have_received(:collate_turbo_tests_coverage!)
+  end
 end
 
 RSpec.describe "rake turbo_tests2:cleanup" do

--- a/spec/kettle/soup/cover_spec.rb
+++ b/spec/kettle/soup/cover_spec.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "open3"
 require "stringio"
 
 RSpec.describe Kettle::Soup::Cover do
@@ -14,6 +15,42 @@ RSpec.describe Kettle::Soup::Cover do
 
     it "has output" do
       expect { reset_const }.to output("CONSTANTS ARE RESET\n").to_stdout
+    end
+
+    it "restores constants after they have been deleted" do
+      Kettle.send(:remove_const, :Change) # rubocop:disable RSpec/RemoveConst
+      described_class.send(:remove_const, :Constants) # rubocop:disable RSpec/RemoveConst
+      described_class.send(:remove_const, :Loaders) # rubocop:disable RSpec/RemoveConst
+
+      expect(Kettle.const_defined?(:Change, false)).to be(false)
+      expect(described_class.const_defined?(:Constants, false)).to be(false)
+      expect(described_class.const_defined?(:Loaders, false)).to be(false)
+
+      expect { described_class.reset_const }.not_to raise_error
+      expect(Kettle.const_defined?(:Change, false)).to be(true)
+      expect(described_class.const_defined?(:Constants, false)).to be(true)
+      expect(described_class.const_defined?(:Loaders, false)).to be(true)
+    end
+  end
+
+  describe "SimpleCov config" do
+    it "leaves turbo_tests2 worker merge finalization to parent collation" do
+      env = {
+        "K_SOUP_COV_FORMATTERS" => "unknown",
+        "K_SOUP_COV_TURBO_TESTS" => "true",
+        "TEST_ENV_NUMBER" => "2"
+      }
+      script = <<~RUBY
+        require "simplecov"
+        require "kettle-soup-cover"
+        require "kettle/soup/cover/config"
+        puts SimpleCov.finalize_merge?
+      RUBY
+
+      stdout, stderr, status = Open3.capture3(env, RbConfig.ruby, "-Ilib", "-e", script)
+
+      expect(status).to be_success, stderr
+      expect(stdout).to eq("false\n")
     end
   end
 
@@ -163,7 +200,7 @@ RSpec.describe Kettle::Soup::Cover do
         stub_const("Kettle::Soup::Cover::Constants::MULTI_FORMATTERS", true)
       end
 
-      it "uses the configured formatter stack so SimpleCov can report from the final worker" do
+      it "uses the configured formatter stack in the worker coverage directory" do
         described_class.configure_formatters!
 
         expect(Kettle::Soup::Cover::Loaders).to have_received(:load_formatters)


### PR DESCRIPTION
## Summary

- write turbo_tests2 worker coverage into `coverage/turbo_tests/<worker>` instead of the shared root coverage directory
- explicitly set SimpleCov worker merge finalization to `false` so `kettle-test` parent collation owns the final report
- cover the worker config path with constants and subprocess config specs

## Why here

`turbo_tests2` already exposes the required worker contract via `TEST_ENV_NUMBER`, `PARALLEL_TEST_GROUPS`, and `PARALLEL_PID_FILE`. `kettle-test` already invokes setup before the run and collation afterward. The inconsistent layer was `kettle-soup-cover`: its collation code looked for `coverage/turbo_tests/*`, while its SimpleCov config still wrote worker reports to the root coverage directory.

## Verification

- `env K_SOUP_COV_MIN_HARD=false K_SOUP_COV_DO=false bundle exec kettle-test spec/kettle/soup/cover/constants_spec.rb spec/kettle/soup/cover_spec.rb`
- `env K_SOUP_COV_MIN_HARD=false K_SOUP_COV_DO=false bundle exec kettle-test`
- `env K_SOUP_COV_DO=true K_SOUP_COV_MIN_HARD=false K_SOUP_COV_FORMATTERS=json K_SOUP_COV_MULTI_FORMATTERS=true bundle exec kettle-test`
- `bin/rake rubocop_gradual:autocorrect`
- `ruby -c lib/kettle/soup/cover/config.rb`
- `ruby -c lib/kettle/soup/cover/constants.rb`
- `git diff --no-ext-diff --check`